### PR TITLE
Ensure that "payload" in fromBase58Check is a buffer

### DIFF
--- a/src/address.js
+++ b/src/address.js
@@ -8,7 +8,7 @@ var typeforce = require('typeforce')
 var types = require('./types')
 
 function fromBase58Check (address) {
-  var payload = bs58check.decode(address)
+  var payload = Buffer.from(bs58check.decode(address))
 
   // TODO: 4.0.0, move to "toOutputScript"
   if (payload.length < 21) throw new TypeError(address + ' is too short')


### PR DESCRIPTION
In certain situations (e.g. on my Ubuntu 16.04 machine with node version 10.15.3), "payload" is not a buffer by default, causing an error when Buffer function readUInt8 is called on it. If this package is used in Agama, and this error occurs, it causes an 'Invalid pub address' error on valid Bitcoin addresses. This fix ensures payload will always be a buffer, and if it is already a buffer by default, it shouldn't cause any issues.